### PR TITLE
chore: 🤖 re-enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    # Disable updates except for vulnerabilities
-    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
     commit-message:
@@ -11,8 +9,6 @@ updates:
       include: "scope"
   - package-ecosystem: "npm"
     directory: "/"
-    # Disable updates except for vulnerabilities
-    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Re-enable Dependabot scheduled version updates (removes `open-pull-requests-limit: 0`, falling back to Dependabot's default limit). Security-only updates are unaffected by this setting and stay as-is.

C.f.: TER-186